### PR TITLE
Fix the merge conflict in the program instructions

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,7 +6,7 @@
 int main()
 {
     std::cout << "Hello User!\nWelcome to the government database for people who don't brush their teeth before bed." << std::endl;
-    std::cout << "Please ensure information disclosed to you through this service is kept confidential, or there may be consequences..." << std::endl;
+    std::cout << "Please ensure information disclosed to you through this service is ALWAYS kept confidential, or there may be consequences..." << std::endl;
 }
 
 // Run program: Ctrl + F5 or Debug > Start Without Debugging menu


### PR DESCRIPTION
The merge conflict in the program instructions was being caused by a slight difference in a line of text. It was fixed by changing the line to be more ambiguous. 